### PR TITLE
feat(chat_completions): support partial mode

### DIFF
--- a/api_chat_completions.go
+++ b/api_chat_completions.go
@@ -30,6 +30,8 @@ func (c *Client) Chat() IChat {
 type ChatCompletionsMessage struct {
 	Role    ChatCompletionsMessageRole `json:"role"`
 	Content string                     `json:"content"`
+	Partial bool                       `json:"partial,omitempty"`
+	Name    string                     `json:"name,omitempty"`
 }
 
 type ChatCompletionsRequest struct {
@@ -88,6 +90,19 @@ func (c *chat) Completions(ctx context.Context, req *ChatCompletionsRequest) (*C
 		return nil, err
 	}
 	return chatCompletionsResp, nil
+}
+
+func (c *ChatCompletionsResponse) GetMessage() (*ChatCompletionsMessage, error) {
+	if len(c.Choices) == 0 {
+		return nil, fmt.Errorf("empty choices")
+	}
+	for _, choice := range c.Choices {
+		if choice.Message != nil {
+			return choice.Message, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no such choice")
 }
 
 type ChatCompletionsStreamResponse struct {

--- a/api_chat_completions_test.go
+++ b/api_chat_completions_test.go
@@ -3,11 +3,14 @@ package moonshot_test
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/northes/go-moonshot"
 	"github.com/northes/go-moonshot/test"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChat(t *testing.T) {
@@ -98,4 +101,35 @@ func TestChatWithContext(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Log(test.MarshalJsonToStringX(resp))
+}
+
+func TestPartialMode(t *testing.T) {
+	cli, err := NewTestClient()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	const leadingText = "{"
+
+	builder := moonshot.NewChatCompletionsBuilder()
+	builder.AddSystemContent("请从产品描述中提取名称、尺寸、价格和颜色，并在一个 JSON 对象中输出。")
+	builder.AddUserContent("大米 SmartHome Mini 是一款小巧的智能家居助手，有黑色和银色两种颜色，售价为 998 元，尺寸为 256 x 128 x 128mm。可让您通过语音或应用程序控制灯光、恒温器和其他联网设备，无论您将它放在家中的任何位置。")
+	builder.AddAssistantContent(leadingText, true)
+	builder.SetTemperature(0.3)
+
+	resp, err := cli.Chat().Completions(ctx, builder.ToRequest())
+	if err != nil {
+		t.Fatal(err)
+	}
+	message, err := resp.GetMessage()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	require.Equal(t, strings.HasPrefix(message.Content, leadingText), false, "message content should not start with '{'")
+
+	jsonStr := fmt.Sprintf("%s%s", leadingText, message.Content)
+
+	t.Log(jsonStr)
 }

--- a/chat_completions_builder.go
+++ b/chat_completions_builder.go
@@ -3,7 +3,7 @@ package moonshot
 type IChatCompletionsBuilder interface {
 	AddUserContent(content string) IChatCompletionsBuilder
 	AddSystemContent(content string) IChatCompletionsBuilder
-	AddAssistantContent(content string) IChatCompletionsBuilder
+	AddAssistantContent(content string, partialMode ...bool) IChatCompletionsBuilder
 	AddPrompt(prompt string) IChatCompletionsBuilder
 	AddMessage(message *ChatCompletionsMessage) IChatCompletionsBuilder
 
@@ -66,11 +66,17 @@ func (c *chatCompletionsBuilder) AddSystemContent(content string) IChatCompletio
 	return c
 }
 
-// AddAssistantContent adds a message with the role of assistant
-func (c *chatCompletionsBuilder) AddAssistantContent(content string) IChatCompletionsBuilder {
+// AddAssistantContent add a message with the role of assistant, and partial mode
+func (c *chatCompletionsBuilder) AddAssistantContent(content string, partialMode ...bool) IChatCompletionsBuilder {
+	var partial bool
+	if len(partialMode) == 1 {
+		partial = partialMode[0]
+	}
+
 	c.req.Messages = append(c.req.Messages, &ChatCompletionsMessage{
 		Role:    RoleAssistant,
 		Content: content,
+		Partial: partial,
 	})
 	return c
 }


### PR DESCRIPTION
**Describe the change**

Support partial mode.

**Provide Moonshot documentation link**

https://platform.moonshot.cn/docs/api/partial#partial-mode

**Describe your solution**

Add `Partial` and `Name` fields to `ChatCompletionsMessage` struct and test code.

**Tests**

Add `TestPartialMode` method in `api_chat_completions_test.go`, pass.

**Additional context**

Nothing.

Issue: #14